### PR TITLE
Finalize period-close event and improve internal part of market watcher

### DIFF
--- a/src/core/watcher/MidaMarketWatcher.ts
+++ b/src/core/watcher/MidaMarketWatcher.ts
@@ -167,6 +167,8 @@ export class MidaMarketWatcher {
         roundMinute.setSeconds(0);
 
         this.#closedPeriodsTimeoutId = setTimeout((): void => {
+            this.#checkNewClosedPeriods();
+
             this.#closedPeriodsIntervalId = setInterval(() => this.#checkNewClosedPeriods(), 60000);
         }, roundMinute.valueOf() + 60000 - actualDate.valueOf() + 60); // Invoke the function the next round minute plus ~0.06s of margin
         // </periods>


### PR DESCRIPTION
## Changelog

### Features
* Expose "period-close" event and `getSymbolDirectives` method in `MidaMarketWatcher` ([#3](https://github.com/Reiryoku-Technologies/Mida/pull/3)).