### PR TITLE
Update internal protection when hook is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Bug fixes
+* Correctly update position protection when `onProtectionChange` is called [#11](https://github.com/Reiryoku-Technologies/Mida/pull/11)
+
 4.0.0 - 27-02-2022
 ===================
 ### Features

--- a/src/core/positions/MidaBrokerPosition.ts
+++ b/src/core/positions/MidaBrokerPosition.ts
@@ -307,18 +307,33 @@ export abstract class MidaBrokerPosition {
     }
 
     protected onProtectionChange (protection: MidaBrokerPositionProtection): void {
-        if (Number.isFinite(protection.takeProfit) && this.#protection.takeProfit !== protection.takeProfit) {
-            this.#protection.takeProfit = protection.takeProfit;
+        const {
+            takeProfit,
+            stopLoss,
+            trailingStopLoss,
+        } = protection;
+        const {
+            takeProfit: actualTakeProfit,
+            stopLoss: actualStopLoss,
+            trailingStopLoss: actualTrailingStopLoss,
+        } = this.#protection;
 
-            this.#emitter.notifyListeners("take-profit-change", { takeProfit: protection.takeProfit, });
+        if (takeProfit !== actualTakeProfit) {
+            this.#protection.takeProfit = takeProfit;
+
+            this.#emitter.notifyListeners("take-profit-change", { takeProfit, });
         }
 
-        if (Number.isFinite(protection.stopLoss)) {
-            this.#emitter.notifyListeners("stop-loss-change", { stopLoss: protection.stopLoss, });
+        if (stopLoss !== actualStopLoss) {
+            this.#protection.stopLoss = stopLoss;
+
+            this.#emitter.notifyListeners("stop-loss-change", { stopLoss, });
         }
 
-        if (Number.isFinite(protection.trailingStopLoss)) {
-            this.#emitter.notifyListeners("trailing-stop-loss-change", { trailingStopLoss: protection.trailingStopLoss, });
+        if (trailingStopLoss !== actualTrailingStopLoss) {
+            this.#protection.trailingStopLoss = actualTrailingStopLoss;
+
+            this.#emitter.notifyListeners("trailing-stop-loss-change", { trailingStopLoss, });
         }
 
         this.#emitter.notifyListeners("protection-change", { protection, });


### PR DESCRIPTION
### Bug fixes
* Correctly update position protection when `onProtectionChange` is called [#11](https://github.com/Reiryoku-Technologies/Mida/pull/11)