### PR TITLE
Don't call on tick if event is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Bug fixes
+* Wait for the `onTick` hook call to resolve before calling the next one [#44](https://github.com/Reiryoku-Technologies/Mida/pull/44)
+
 7.2.0 - 15-06-2022
 ===================
 ### Features

--- a/src/core/systems/MidaTradingSystem.ts
+++ b/src/core/systems/MidaTradingSystem.ts
@@ -246,9 +246,11 @@ export abstract class MidaTradingSystem {
         this.#onTickAsync(tick);
     }
 
-    async #onTickAsync (tick: MidaTick): Promise<void> {
-        if (this.#tickEventIsLocked) {
+    async #onTickAsync (tick: MidaTick, bypassLock: boolean = false): Promise<void> {
+        if (this.#tickEventIsLocked && !bypassLock) {
             this.#tickEventQueue.push(tick);
+
+            return;
         }
 
         this.#tickEventIsLocked = true;
@@ -281,10 +283,12 @@ export abstract class MidaTradingSystem {
         }
 
         const nextTick: MidaTick | undefined = this.#tickEventQueue.shift();
-        this.#tickEventIsLocked = false;
 
         if (nextTick) {
-            this.#onTickAsync(nextTick);
+            this.#onTickAsync(nextTick, true);
+        }
+        else {
+            this.#tickEventIsLocked = false;
         }
     }
 


### PR DESCRIPTION
### Bug fixes
* Wait for the `onTick` hook call to resolve before calling the next one [#44](https://github.com/Reiryoku-Technologies/Mida/pull/44)