### PR TITLE
fix: Too few candles returned

### DIFF
--- a/src/platforms/ctrader/CTraderAccount.ts
+++ b/src/platforms/ctrader/CTraderAccount.ts
@@ -216,7 +216,8 @@ export class CTraderAccount extends MidaTradingAccount {
     }
 
     public override async getSymbolPeriods (symbol: string, timeframe: MidaTimeframe): Promise<MidaPeriod[]> {
-        const W1: number = MidaTimeframe.toSeconds("W1") as number;
+        // cTrader protooagettrendbarsreq works in milliseconds
+        const W1: number = MidaTimeframe.toSeconds("W1") as number*1000;
         const now: number = Date.now();
         const stringTimeframe: string = timeframe;
         let from = now - W1;


### PR DESCRIPTION
cTrader handles `from` and `to` timestamps i milliseconds. Currently too few candles are returned. 

https://help.ctrader.com/open-api/messages/#protooagettrendbarsreq

I added a 1000 multiplier and this seems to work:

## Example of error
```
const candlesticks = await this.tradingAccount.getSymbolPeriods("EURUSD", MidaTimeframe.H1);
console.log("length: " + candlesticks.length);   
output = length: 6
```