### PR TITLE
Added S1 timeframe support for binance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Features
+Binance | Add `S1` timeframe [#114](https://github.com/Reiryoku-Technologies/Mida/pull/114)
+
 2023.3.0 - 14-05-2023
 ===================
 ### Features

--- a/README.md
+++ b/README.md
@@ -656,3 +656,4 @@ may lead to money loss, for example a stop loss not being set.
 | Karsten Jakobsen | Collaborator           | [karstenjakobsen](https://github.com/karstenjakobsen) | /                         |
 | JoeGuest         | Collaborator           | [JoeGuest](https://github.com/JoeGuest)               | /                         |
 | Yannick Jemmely  | Collaborator           | [yannickjemmely](https://github.com/yannickjemmely)   | /                         |
+| Lorenzo Iovino   | Collaborator           | [lokenxo](https://github.com/lokenxo)                 | /                         |

--- a/src/platforms/binance/spot/utilities/BinanceSpotUtilities.ts
+++ b/src/platforms/binance/spot/utilities/BinanceSpotUtilities.ts
@@ -45,6 +45,9 @@ export namespace BinanceSpotUtilities {
 
     export const toBinanceTimeframe = (timeframe: MidaTimeframe): string => {
         switch (timeframe) {
+            case MidaTimeframe.S1: {
+                return "1s";
+            }
             case MidaTimeframe.M1: {
                 return "1m";
             }
@@ -112,6 +115,9 @@ export namespace BinanceSpotUtilities {
 
     export const normalizeTimeframe = (timeframe: string): MidaTimeframe => {
         switch (timeframe) {
+            case "1s": {
+                return MidaTimeframe.S1;
+            }
             case "1m": {
                 return MidaTimeframe.M1;
             }


### PR DESCRIPTION
Added mapping binance/Mida Mida/binance for the 1 second timeframe _S1 <-> 1s_

### Features
 Binance | Add `S1` timeframe [#114](https://github.com/Reiryoku-Technologies/Mida/pull/114)